### PR TITLE
Adds ability to start managed daemon in the debug mode

### DIFF
--- a/container-common/src/main/java/org/jboss/arquillian/daemon/container/common/DaemonContainerConfigurationBase.java
+++ b/container-common/src/main/java/org/jboss/arquillian/daemon/container/common/DaemonContainerConfigurationBase.java
@@ -26,50 +26,30 @@ public class DaemonContainerConfigurationBase implements ContainerConfiguration 
 
     // Properties
     private String host;
-    private String port;
+    private Integer port;
 
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.jboss.arquillian.container.spi.client.container.ContainerConfiguration#validate()
-     */
     @Override
     public void validate() throws ConfigurationException {
         if (host == null || host.length() == 0) {
             throw new ConfigurationException("host must be specified");
         }
-        if (port == null || port.length() == 0) {
-            throw new ConfigurationException("port must be specified");
+        if (port == null || port < 1 || port > 65536) {
+            throw new ConfigurationException("port must be specified within the range of [1-65563]");
         }
     }
-
-    /**
-     * @return the host
-     */
     public String getHost() {
         return host;
     }
 
-    /**
-     * @param host
-     *            the host to set
-     */
     public void setHost(String host) {
         this.host = host;
     }
 
-    /**
-     * @return the port
-     */
-    public String getPort() {
+    public Integer getPort() {
         return port;
     }
 
-    /**
-     * @param port
-     *            the port to set
-     */
-    public void setPort(String port) {
+    public void setPort(Integer port) {
         this.port = port;
     }
 

--- a/container-common/src/main/java/org/jboss/arquillian/daemon/container/common/DaemonDeployableContainerBase.java
+++ b/container-common/src/main/java/org/jboss/arquillian/daemon/container/common/DaemonDeployableContainerBase.java
@@ -63,8 +63,8 @@ public abstract class DaemonDeployableContainerBase<CONFIGTYPE extends DaemonCon
     @Override
     public void setup(final CONFIGTYPE configuration) {
         final String remoteHost = configuration.getHost();
-        final String remotePort = configuration.getPort();
-        final InetSocketAddress address = new InetSocketAddress(remoteHost, Integer.parseInt(remotePort));
+        final Integer remotePort = configuration.getPort();
+        final InetSocketAddress address = new InetSocketAddress(remoteHost, remotePort);
         this.remoteAddress = address;
     }
 
@@ -76,7 +76,7 @@ public abstract class DaemonDeployableContainerBase<CONFIGTYPE extends DaemonCon
             final long startTime = System.currentTimeMillis();
             final int secondsToWait = 10;
             final long acceptableTime = startTime + 1000 * secondsToWait; // 10 seconds from now
-            Socket socket = null;
+            Socket socket;
             while (true) {
                 try {
                     // TODO Security Action

--- a/container-managed/pom.xml
+++ b/container-managed/pom.xml
@@ -42,14 +42,22 @@
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <!-- <scope>test</scope>   -->
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${version.assertj}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <properties>
+    <version.assertj>2.5.0</version.assertj>
+  </properties>
 
   <build>
     <plugins>

--- a/container-managed/src/main/java/org/jboss/arquillian/daemon/container/managed/ManagedDaemonContainerConfiguration.java
+++ b/container-managed/src/main/java/org/jboss/arquillian/daemon/container/managed/ManagedDaemonContainerConfiguration.java
@@ -16,11 +16,13 @@
  */
 package org.jboss.arquillian.daemon.container.managed;
 
-import java.io.File;
-
 import org.jboss.arquillian.container.spi.ConfigurationException;
 import org.jboss.arquillian.container.spi.client.container.ContainerConfiguration;
 import org.jboss.arquillian.daemon.container.common.DaemonContainerConfigurationBase;
+
+import java.io.File;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 
 /**
  * {@link ContainerConfiguration} implementation for Managed Containers
@@ -28,41 +30,157 @@ import org.jboss.arquillian.daemon.container.common.DaemonContainerConfiguration
  * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
  */
 public class ManagedDaemonContainerConfiguration extends DaemonContainerConfigurationBase implements
-    ContainerConfiguration {
+        ContainerConfiguration {
+
+    private String javaHome = SecurityActions.getSystemProperty("java.home");
+
+    private boolean debug;
+
+    private boolean suspend = true;
+
+    private int debugPort = 54321;
 
     private String serverJarFile;
 
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.jboss.arquillian.container.spi.client.container.ContainerConfiguration#validate()
-     */
     @Override
     public void validate() throws ConfigurationException {
         super.validate();
         if (serverJarFile == null || serverJarFile.length() == 0) {
             throw new ConfigurationException("\"serverJarFile\" must be specified");
         }
+
+        if (debugPort < 1 || debugPort > 65536) {
+            throw new ConfigurationException("port must be specified within the range of [1-65563]");
+        }
+
         final File file = new File(serverJarFile);
         if (!file.exists() || file.isDirectory()) {
             throw new ConfigurationException("Server JAR file must exist and not be a directory: "
-                + file.getAbsolutePath());
+                    + file.getAbsolutePath());
         }
     }
 
-    /**
-     * @return the serverJarFile
-     */
     public String getServerJarFile() {
         return serverJarFile;
     }
 
-    /**
-     * @param serverJarFile
-     *            the serverJarFile to set
-     */
     public void setServerJarFile(final String serverJarFile) {
         this.serverJarFile = serverJarFile;
     }
 
+    public String getJavaHome() {
+        return javaHome;
+    }
+
+    public void setJavaHome(String javaHome) {
+        this.javaHome = javaHome;
+    }
+
+    public boolean isDebug() {
+        return debug;
+    }
+
+    public void setDebug(boolean debug) {
+        this.debug = debug;
+    }
+
+    public boolean isSuspend() {
+        return suspend;
+    }
+
+    public void setSuspend(boolean suspend) {
+        this.suspend = suspend;
+    }
+
+    public int getDebugPort() {
+        return debugPort;
+    }
+
+    public void setDebugPort(int debugPort) {
+        this.debugPort = debugPort;
+    }
+
+    private static final class SecurityActions {
+        private SecurityActions() {
+            throw new UnsupportedOperationException("No instance permitted");
+        }
+
+        static String getSystemProperty(final String key) {
+            assert key != null && key.length() > 0 : "key must be specified";
+            if (System.getSecurityManager() == null) {
+                return System.getProperty(key);
+            }
+            return AccessController.doPrivileged(new PrivilegedAction<String>() {
+                @Override
+                public String run() {
+                    return System.getProperty(key);
+                }
+            });
+        }
+    }
+
+    public static ManagedDaemonContainerConfigurationBuilder create() {
+        return new ManagedDaemonContainerConfigurationBuilder();
+    }
+
+    public static final class ManagedDaemonContainerConfigurationBuilder {
+        private String host;
+        private Integer port;
+        private String javaHome = SecurityActions.getSystemProperty("java.home");
+        private boolean debug;
+        private boolean suspend = true;
+        private int debugPort = 54321;
+        private String serverJarFile;
+
+        private ManagedDaemonContainerConfigurationBuilder() {
+        }
+
+
+        public ManagedDaemonContainerConfigurationBuilder withHost(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public ManagedDaemonContainerConfigurationBuilder withPort(Integer port) {
+            this.port = port;
+            return this;
+        }
+
+        public ManagedDaemonContainerConfigurationBuilder withJavaHome(String javaHome) {
+            this.javaHome = javaHome;
+            return this;
+        }
+
+        public ManagedDaemonContainerConfigurationBuilder withDebug() {
+            this.debug = true;
+            return this;
+        }
+
+        public ManagedDaemonContainerConfigurationBuilder withSuspend() {
+            this.suspend = true;
+            return this;
+        }
+
+        public ManagedDaemonContainerConfigurationBuilder withDebugPort(int debugPort) {
+            this.debugPort = debugPort;
+            return this;
+        }
+
+        public ManagedDaemonContainerConfigurationBuilder withServerJarFile(String serverJarFile) {
+            this.serverJarFile = serverJarFile;
+            return this;
+        }
+
+        public ManagedDaemonContainerConfiguration build() {
+            ManagedDaemonContainerConfiguration managedDaemonContainerConfiguration = new ManagedDaemonContainerConfiguration();
+            managedDaemonContainerConfiguration.setHost(host);
+            managedDaemonContainerConfiguration.setPort(port);
+            managedDaemonContainerConfiguration.setJavaHome(javaHome);
+            managedDaemonContainerConfiguration.setDebug(debug);
+            managedDaemonContainerConfiguration.setSuspend(suspend);
+            managedDaemonContainerConfiguration.setDebugPort(debugPort);
+            managedDaemonContainerConfiguration.setServerJarFile(serverJarFile);
+            return managedDaemonContainerConfiguration;
+        }
+    }
 }

--- a/container-managed/src/test/java/org/jboss/arquillian/daemon/container/managed/ManagedDaemonDeployableContainerTest.java
+++ b/container-managed/src/test/java/org/jboss/arquillian/daemon/container/managed/ManagedDaemonDeployableContainerTest.java
@@ -1,0 +1,54 @@
+package org.jboss.arquillian.daemon.container.managed;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ManagedDaemonDeployableContainerTest {
+
+    private final ManagedDaemonDeployableContainer managedDaemonDeployableContainer = new ManagedDaemonDeployableContainer();
+
+    @Test
+    public void should_generate_cli_command_with_defined_host_and_port() {
+        // given
+        final ManagedDaemonContainerConfiguration managedDaemonContainerConfiguration = ManagedDaemonContainerConfiguration.create()
+                .withHost("custom-host")
+                .withPort(9999)
+                .withServerJarFile("arq-daemon.jar")
+                .build();
+
+        managedDaemonDeployableContainer.setup(managedDaemonContainerConfiguration);
+
+        // when
+        final List<String> commands = managedDaemonDeployableContainer.buildCommand();
+
+        // then
+        assertThat(commands)
+                .containsSubsequence("-jar", "custom-host", "9999")
+                .doesNotContain("-agentlib:jdwp=transport=dt_socket,address=8181,server=y,suspend=y");
+    }
+
+    @Test
+    public void should_generate_cli_command_with_debug_agent() {
+        // given
+        final ManagedDaemonContainerConfiguration managedDaemonContainerConfiguration = ManagedDaemonContainerConfiguration.create()
+                .withHost("localhost")
+                .withPort(8080)
+                .withServerJarFile("arq-daemon.jar")
+                .withDebug()
+                .withSuspend()
+                .withDebugPort(8181)
+                .build();
+
+        managedDaemonDeployableContainer.setup(managedDaemonContainerConfiguration);
+
+        // when
+        final List<String> commands = managedDaemonDeployableContainer.buildCommand();
+
+        // then
+        assertThat(commands).containsSequence("-agentlib:jdwp=transport=dt_socket,address=8181,server=y,suspend=y", "-jar");
+    }
+
+}

--- a/container-managed/src/test/resources/arquillian.xml
+++ b/container-managed/src/test/resources/arquillian.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <arquillian xmlns="http://jboss.org/schema/arquillian"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <container qualifier="daemon" default="true">
-        <configuration>
-            <property name="host">localhost</property>
-            <property name="port">12345</property>
-            <property name="serverJarFile">target/arquillian-daemon-main.jar</property>
-        </configuration>
-    </container>
+  <container qualifier="daemon" default="true">
+    <configuration>
+      <property name="host">localhost</property>
+      <property name="port">12345</property>
+      <property name="serverJarFile">target/arquillian-daemon-main.jar</property>
+      <property name="debug">false</property>
+    </configuration>
+  </container>
 </arquillian>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <version.org.jboss.modules>1.1.3.GA</version.org.jboss.modules>
-    <version.io.netty_netty>4.0.0.Alpha5</version.io.netty_netty>
+    <version.io.netty_netty>4.0.0.Alpha8</version.io.netty_netty>
   </properties>
 
   <artifactId>arquillian-daemon-main</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <version.org.jboss.modules>1.1.3.GA</version.org.jboss.modules>
-    <version.io.netty_netty>4.0.0.Alpha5</version.io.netty_netty>
+    <version.io.netty_netty>4.0.0.Alpha8</version.io.netty_netty>
   </properties>
 
   <artifactId>arquillian-daemon-server</artifactId>


### PR DESCRIPTION
Configuration for `daemon` has been extended to start `jar` with `agentlib` on specified port and optionally suspending the process until the remote debugger session is attached.

@lordofthejars review more than welcome